### PR TITLE
Bot v0.4.0 f1 integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,11 +79,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -98,13 +99,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -115,6 +116,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -151,9 +158,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bitflags"
@@ -163,9 +170,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -181,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecount"
@@ -199,9 +206,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -236,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "shlex",
 ]
@@ -295,7 +302,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -363,9 +370,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -444,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "der"
@@ -461,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -489,7 +496,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -506,9 +513,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -524,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -577,9 +584,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -604,9 +611,24 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -683,7 +705,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -790,6 +812,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -888,10 +929,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.9.5"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -909,9 +973,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -924,6 +988,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.8",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,10 +1015,62 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls 0.23.25",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1075,7 +1211,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1101,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1111,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1123,15 +1259,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1154,9 +1290,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -1176,15 +1312,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1251,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1267,6 +1403,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1342,9 +1495,53 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -1425,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -1437,18 +1634,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1459,16 +1656,16 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "memchr",
  "unicase",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1498,7 +1695,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1541,11 +1738,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1559,11 +1756,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -1573,12 +1770,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -1593,25 +1790,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.8"
+name = "reqwest"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.8",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -1635,11 +1875,11 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1673,6 +1913,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,10 +1935,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.1"
+name = "rustls-pemfile"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -1709,10 +1971,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustls-webpki"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1721,6 +2000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1750,19 +2038,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.24"
+name = "security-framework"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -1778,20 +2089,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1829,7 +2140,7 @@ dependencies = [
  "arrayvec",
  "async-trait",
  "base64 0.22.1",
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bytes",
  "chrono",
  "command_attr",
@@ -1841,7 +2152,7 @@ dependencies = [
  "mime_guess",
  "parking_lot",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.27",
  "secrecy",
  "serde",
  "serde_cow",
@@ -1941,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -2017,7 +2328,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2034,7 +2345,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2057,7 +2368,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.96",
+ "syn 2.0.100",
  "tempfile",
  "tokio",
  "url",
@@ -2071,7 +2382,7 @@ checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2101,7 +2412,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
@@ -2114,7 +2425,7 @@ checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2139,7 +2450,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "whoami",
 ]
@@ -2216,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2232,6 +2543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2559,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2250,7 +2570,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -2264,6 +2595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,13 +2612,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2303,11 +2643,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2318,25 +2658,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -2351,15 +2691,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2377,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2416,7 +2756,17 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2437,6 +2787,16 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -2464,14 +2824,14 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tungstenite",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2515,6 +2875,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,7 +2921,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2573,7 +2954,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -2593,15 +2974,15 @@ checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typesize"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20304d891be0766f52123746c721d1190b953e874f9eccf29067a64c1a0ae16c"
+checksum = "e29e4cac0f1acdbbe7b4deb46876a04246dc6abf60b6f2587bef8ae327cd134c"
 dependencies = [
  "chrono",
  "dashmap",
@@ -2623,7 +3004,7 @@ checksum = "536b6812192bda8551cfa0e52524e328c6a951b48e66529ee4522d6c721243d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2640,9 +3021,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -2771,34 +3152,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2809,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2819,22 +3201,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -2851,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "wdl_discord_bot"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2859,6 +3244,9 @@ dependencies = [
  "dotenv",
  "log",
  "rand 0.9.0",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
  "serenity",
  "simplelog",
  "sqlx",
@@ -2870,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2886,9 +3274,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2927,6 +3315,35 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2979,11 +3396,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2999,6 +3432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3448,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3023,10 +3468,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3041,6 +3498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3514,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3065,6 +3534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3550,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3101,7 +3582,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3136,18 +3617,8 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
@@ -3156,18 +3627,7 @@ version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3178,27 +3638,27 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3227,5 +3687,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl_discord_bot"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -15,6 +15,7 @@ clap = { version = "4.5.32", features = ["derive"] }
 colored = "3.0.0"
 dotenv = "0.15.0"
 rand = "0.9.0"
+reqwest = { version = "0.12.15", features = ["json"] }
 serenity = { version = "0.12.4", features = ["collector", "model", "chrono"] }
 sqlx = { version = "0.8.3", features = ["mysql", "runtime-tokio", "chrono"] }
 tokio = { version = "1.44.1", features = ["full"] }
@@ -22,5 +23,7 @@ uuid = { version = "1.16.0", features = ["v4", "fast-rng"] }
 whoami = "1.5.2"
 log = { version = "0.4.26"}
 simplelog = "0.12.2"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 
 

--- a/src/commands/f1/api.rs
+++ b/src/commands/f1/api.rs
@@ -1,0 +1,35 @@
+use chrono::{Datelike, Local, NaiveDate, Utc, Weekday};
+use log::info;
+use std::str::FromStr;
+
+use crate::commands::f1::models::*;
+
+// Function to fetch F1 calendar for the current year
+pub async fn fetch_f1_calendar() -> Result<F1Calendar, reqwest::Error> {
+    let current_year = Utc::now().year().to_string();
+    let url = format!("https://api.jolpi.ca/ergast/f1/{}/races.json", current_year);
+    info!("Fetching F1 calendar for year: {}", current_year);
+    
+    let client = reqwest::Client::new();
+    let response = client.get(&url).send().await?;
+    
+    response.json::<F1Calendar>().await
+}
+
+// Function to find the next upcoming race
+pub fn find_next_race(races: &[Race]) -> Option<Race> {
+    let today = Local::now().date_naive();
+    
+    races.iter()
+        .find(|race| {
+            NaiveDate::from_str(&race.date).ok()
+                .filter(|race_date| *race_date >= today)
+                .is_some()
+        })
+        .cloned()
+}
+
+// Check if today is Thursday
+pub fn is_thursday() -> bool {
+    Local::now().weekday() == Weekday::Thu
+} 

--- a/src/commands/f1/api.rs
+++ b/src/commands/f1/api.rs
@@ -8,7 +8,7 @@ use crate::commands::f1::models::*;
 pub async fn fetch_f1_calendar() -> Result<F1Calendar, reqwest::Error> {
     let current_year = Utc::now().year().to_string();
     let url = format!("https://api.jolpi.ca/ergast/f1/{}/races.json", current_year);
-    info!("Fetching F1 calendar for year: {}", current_year);
+    info!("fetch_f1_calendar: Fetching F1 calendar for year: {}", current_year);
     
     let client = reqwest::Client::new();
     let response = client.get(&url).send().await?;

--- a/src/commands/f1/embed.rs
+++ b/src/commands/f1/embed.rs
@@ -43,6 +43,6 @@ pub fn create_race_embed(race: &Race) -> CreateEmbed {
             format!("**{}** days until race day!", days_until),
             false
         )
-        .footer(CreateEmbedFooter::new("Data provided by Ergast F1 API"))
+        .footer(CreateEmbedFooter::new("Data provided by api.jolpi.ca F1 API"))
         .timestamp(Timestamp::now())
 } 

--- a/src/commands/f1/embed.rs
+++ b/src/commands/f1/embed.rs
@@ -1,0 +1,48 @@
+use chrono::{Local, NaiveDate};
+use serenity::{
+    all::{CreateEmbed},
+    builder::{CreateEmbedFooter},
+    model::Timestamp,
+};
+use std::str::FromStr;
+
+use crate::commands::f1::models::Race;
+
+// Function to create a rich embed for the race announcement
+pub fn create_race_embed(race: &Race) -> CreateEmbed {
+    let race_date = NaiveDate::from_str(&race.date).unwrap_or_default();
+    let today = Local::now().date_naive();
+    let days_until = race_date.signed_duration_since(today).num_days();
+    
+    let embed = CreateEmbed::default();
+    embed
+        .title(format!("🏎️ Upcoming F1 Race: {} 🏎️", race.race_name))
+        .color(0xFF1801) // F1 red color
+        .thumbnail("https://www.formula1.com/etc/designs/fom-website/images/f1_logo.png")
+        .description(format!(
+            "**Round {}** of the Formula 1 Championship is coming up!",
+            race.round
+        ))
+        .field(
+            "Circuit",
+            format!("{}", race.circuit.circuit_name),
+            true
+        )
+        .field(
+            "Location",
+            format!("{}, {}", race.circuit.location.locality, race.circuit.location.country),
+            true
+        )
+        .field(
+            "Date & Time",
+            format!("{} {}", race.date, if !race.time.is_empty() { &race.time } else { "TBA" }),
+            true
+        )
+        .field(
+            "Countdown",
+            format!("**{}** days until race day!", days_until),
+            false
+        )
+        .footer(CreateEmbedFooter::new("Data provided by Ergast F1 API"))
+        .timestamp(Timestamp::now())
+} 

--- a/src/commands/f1/mod.rs
+++ b/src/commands/f1/mod.rs
@@ -1,0 +1,8 @@
+mod models;
+mod api;
+mod embed;
+mod commands;
+mod registry;
+
+pub use commands::{handle_commands, check_upcoming_race};
+pub use registry::register; 

--- a/src/commands/f1/models.rs
+++ b/src/commands/f1/models.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct F1Calendar {
+    #[serde(rename = "MRData")]
+    pub mr_data: MRData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MRData {
+    #[serde(rename = "RaceTable")]
+    pub race_table: RaceTable,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RaceTable {
+    #[serde(rename = "Races")]
+    pub races: Vec<Race>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Race {
+    #[serde(rename = "raceName")]
+    pub race_name: String,
+    #[serde(rename = "Circuit")]
+    pub circuit: Circuit,
+    #[serde(rename = "date")]
+    pub date: String,
+    #[serde(rename = "time", default)]
+    pub time: String,
+    #[serde(rename = "round")]
+    pub round: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Circuit {
+    #[serde(rename = "circuitName")]
+    pub circuit_name: String,
+    #[serde(rename = "Location")]
+    pub location: Location,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Location {
+    #[serde(rename = "locality")]
+    pub locality: String,
+    #[serde(rename = "country")]
+    pub country: String,
+} 

--- a/src/commands/f1/registry.rs
+++ b/src/commands/f1/registry.rs
@@ -1,0 +1,16 @@
+use serenity::{
+    all::{CommandOptionType, CreateCommand},
+    builder::CreateCommandOption,
+};
+
+// Function to register the F1 command with subcommands
+pub fn register() -> CreateCommand {
+    let next_option = CreateCommandOption::new(CommandOptionType::SubCommand, "next", "Show the next upcoming F1 race");
+    let season_option = CreateCommandOption::new(CommandOptionType::SubCommand, "season", "Show all races for the current F1 season");
+    
+    CreateCommand::new("f1")
+        .description("Check F1 race information")
+        .dm_permission(true)
+        .add_option(next_option)
+        .add_option(season_option)
+} 

--- a/src/commands/f1_race.rs
+++ b/src/commands/f1_race.rs
@@ -1,0 +1,313 @@
+use chrono::{Datelike, Local, NaiveDate, Utc, Weekday};
+use log::{error, info};
+use serenity::{
+    all::{
+        ChannelId, CommandInteraction, CommandOptionType, CreateCommand, CreateEmbed,CreateInteractionResponseFollowup
+    },
+    builder::{CreateCommandOption, CreateEmbedFooter, CreateMessage},
+    model::Timestamp,
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct F1Calendar {
+    #[serde(rename = "MRData")]
+    mr_data: MRData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MRData {
+    #[serde(rename = "RaceTable")]
+    race_table: RaceTable,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RaceTable {
+    #[serde(rename = "Races")]
+    races: Vec<Race>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct Race {
+    #[serde(rename = "raceName")]
+    race_name: String,
+    #[serde(rename = "Circuit")]
+    circuit: Circuit,
+    #[serde(rename = "date")]
+    date: String,
+    #[serde(rename = "time", default)]
+    time: String,
+    #[serde(rename = "round")]
+    round: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct Circuit {
+    #[serde(rename = "circuitName")]
+    circuit_name: String,
+    #[serde(rename = "Location")]
+    location: Location,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct Location {
+    #[serde(rename = "locality")]
+    locality: String,
+    #[serde(rename = "country")]
+    country: String,
+}
+
+// Function to fetch F1 calendar for the current year
+async fn fetch_f1_calendar() -> Result<F1Calendar, reqwest::Error> {
+    let current_year = Utc::now().year().to_string();
+    let url = format!("https://api.jolpi.ca/ergast/f1/{}/races.json", current_year);
+    
+    let client = reqwest::Client::new();
+    let response = client.get(&url).send().await?;
+    
+    response.json::<F1Calendar>().await
+}
+
+// Function to find the next upcoming race
+fn find_next_race(races: &[Race]) -> Option<Race> {
+    let today = Local::now().date_naive();
+    
+    races.iter()
+        .find(|race| {
+            NaiveDate::from_str(&race.date).ok()
+                .filter(|race_date| *race_date >= today)
+                .is_some()
+        })
+        .cloned()
+}
+
+// Check if today is Thursday
+fn is_thursday() -> bool {
+    Local::now().weekday() == Weekday::Thu
+}
+
+// Function to create a rich embed for the race announcement
+fn create_race_embed(race: &Race) -> CreateEmbed {
+    let race_date = NaiveDate::from_str(&race.date).unwrap_or_default();
+    let today = Local::now().date_naive();
+    let days_until = race_date.signed_duration_since(today).num_days();
+    
+    let embed = CreateEmbed::default();
+    embed
+        .title(format!("🏎️ Upcoming F1 Race: {} 🏎️", race.race_name))
+        .color(0xFF1801) // F1 red color
+        .thumbnail("https://www.formula1.com/etc/designs/fom-website/images/f1_logo.png")
+        .description(format!(
+            "**Round {}** of the Formula 1 Championship is coming up!",
+            race.round
+        ))
+        .field(
+            "Circuit",
+            format!("{}", race.circuit.circuit_name),
+            true
+        )
+        .field(
+            "Location",
+            format!("{}, {}", race.circuit.location.locality, race.circuit.location.country),
+            true
+        )
+        .field(
+            "Date & Time",
+            format!("{} {}", race.date, if !race.time.is_empty() { &race.time } else { "TBA" }),
+            true
+        )
+        .field(
+            "Countdown",
+            format!("**{}** days until race day!", days_until),
+            false
+        )
+        .footer(CreateEmbedFooter::new("Data provided by Ergast F1 API"))
+        .timestamp(Timestamp::now())
+}
+
+// Function to register the F1 command with subcommands
+pub fn register() -> CreateCommand {
+    let next_option = CreateCommandOption::new(CommandOptionType::SubCommand, "next", "Show the next upcoming F1 race");
+    let season_option = CreateCommandOption::new(CommandOptionType::SubCommand, "season", "Show all races for the current F1 season");
+    
+    CreateCommand::new("f1")
+        .description("Check F1 race information")
+        .dm_permission(true)
+        .add_option(next_option)
+        .add_option(season_option)
+}
+
+// Command handler for the f1 command and its subcommands
+pub async fn handle_commands(ctx: Context, command: &CommandInteraction) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Defer the response to buy time to fetch data
+    command.defer(&ctx.http).await?;
+    
+    match command.data.options.get(0) {
+        Some(option) => match option.name.as_str() {
+            "next" => show_next_race(ctx, command).await?,
+            "season" => show_season_races(ctx, command).await?,
+            _ => {
+                command.create_followup(&ctx.http, CreateInteractionResponseFollowup::new()
+                    .content("Unknown subcommand.")
+                ).await?;
+            }
+        },
+        None => {
+            // Default to showing the next race if no subcommand specified
+            show_next_race(ctx, command).await?
+        }
+    }
+    
+    Ok(())
+}
+
+// Function to check for upcoming F1 races and announce them on Thursdays
+pub async fn check_upcoming_race(ctx: Context, channel_id: ChannelId) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Only proceed if today is Thursday
+    if !is_thursday() {
+        return Ok(());
+    }
+    
+    info!("It's Thursday, checking for upcoming F1 races...");
+    
+    // Fetch F1 calendar
+    match fetch_f1_calendar().await {
+        Ok(calendar) => {
+            if let Some(next_race) = find_next_race(&calendar.mr_data.race_table.races) {
+                // Calculate if the race is this weekend (within the next 4 days)
+                let race_date = NaiveDate::from_str(&next_race.date).unwrap_or_default();
+                let today = Local::now().date_naive();
+                let days_until = race_date.signed_duration_since(today).num_days();
+                
+                if days_until <= 4 {
+                    // Race is this weekend, send announcement
+                    let embed = create_race_embed(&next_race);
+                    
+                    let message = CreateMessage::new()
+                        .content("**F1 RACE WEEKEND ALERT!**")
+                        .add_embed(embed);
+                    if let Err(why) = channel_id.send_message(&ctx.http, message).await {
+                        error!("Error sending F1 race announcement: {:?}", why);
+                    } else {
+                        info!("F1 race announcement sent successfully!");
+                    }
+                } else {
+                    info!("Next F1 race is in {} days, not announcing yet.", days_until);
+                }
+            } else {
+                info!("No upcoming F1 races found.");
+            }
+        }
+        Err(e) => {
+            error!("Failed to fetch F1 calendar: {:?}", e);
+        }
+    }
+    
+    Ok(())
+}
+
+// Command handler for the f1 command
+async fn show_next_race(ctx: Context, command: &CommandInteraction) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Fetch F1 calendar
+    match fetch_f1_calendar().await {
+        Ok(calendar) => {
+            if let Some(next_race) = find_next_race(&calendar.mr_data.race_table.races) {
+                let embed = create_race_embed(&next_race);
+                
+                // Respond with the embed
+                let message = CreateInteractionResponseFollowup::new().add_embed(embed);
+                command.create_followup(&ctx.http, message).await?;
+            } else {
+                let message = CreateInteractionResponseFollowup::new()
+                    .content("No upcoming F1 races found for the current season.");
+                command.create_followup(&ctx.http, message).await?;
+            }
+        }
+        Err(e) => {
+            error!("Failed to fetch F1 calendar: {:?}", e);
+            let message = CreateInteractionResponseFollowup::new()
+                .content("Failed to fetch F1 calendar. Please try again later.");
+            command.create_followup(&ctx.http, message).await?;
+        }
+    }
+    
+    Ok(())
+}
+
+// Function to show all races for the current season
+async fn show_season_races(ctx: Context, command: &CommandInteraction) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Fetch F1 calendar
+    match fetch_f1_calendar().await {
+        Ok(calendar) => {
+            let today = Local::now().date_naive();
+            let races = &calendar.mr_data.race_table.races;
+            
+            if races.is_empty() {
+                let message = CreateInteractionResponseFollowup::new()
+                    .content("No F1 races found for the current season.");
+                command.create_followup(&ctx.http, message).await?;
+                return Ok(());
+            }
+            
+            // Create an embed with all races
+            let embed = CreateEmbed::default();
+            let embed = embed
+                .title(format!("🏎️ {} F1 Season Calendar 🏎️", Utc::now().year()))
+                .color(0xFF1801)
+                .thumbnail("https://www.formula1.com/etc/designs/fom-website/images/f1_logo.png")
+                .description("Here are all the races for the current Formula 1 season:")
+                .footer(CreateEmbedFooter::new("Data provided by Ergast F1 API"))
+                .timestamp(Timestamp::now());
+            
+            // Add fields for each race with status
+            let embed = races.iter().fold(embed, |embed, race| {
+                let race_date = NaiveDate::from_str(&race.date).unwrap_or_default();
+                let status = if race_date < today {
+                    "✅ Completed"
+                } else if race_date == today {
+                    "🏁 Today!"
+                } else {
+                    "⏳ Upcoming"
+                };
+                
+                let days_until = race_date.signed_duration_since(today).num_days();
+                let time_info = if days_until < 0 {
+                    format!("{} days ago", days_until.abs())
+                } else if days_until == 0 {
+                    "Today!".to_string()
+                } else {
+                    format!("In {} days", days_until)
+                };
+                
+                embed.field(
+                    format!("Round {} - {}", race.round, race.race_name),
+                    format!(
+                        "**Circuit:** {}\n**Location:** {}, {}\n**Date:** {} {}\n**Status:** {} ({})",
+                        race.circuit.circuit_name,
+                        race.circuit.location.locality,
+                        race.circuit.location.country,
+                        race.date,
+                        if !race.time.is_empty() { &race.time } else { "TBA" },
+                        status,
+                        time_info
+                    ),
+                    false
+                )
+            });
+            
+            // Respond with the embed
+            let message = CreateInteractionResponseFollowup::new().add_embed(embed);
+            command.create_followup(&ctx.http, message).await?;
+        }
+        Err(e) => {
+            error!("Failed to fetch F1 calendar: {:?}", e);
+            let message = CreateInteractionResponseFollowup::new()
+                .content("Failed to fetch F1 calendar. Please try again later.");
+            command.create_followup(&ctx.http, message).await?;
+        }
+    }
+    
+    Ok(())
+} 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,4 @@
 pub mod quote;
 pub mod scraper;
 pub mod version;
-pub mod f1_race;
+pub mod f1;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod quote;
 pub mod scraper;
 pub mod version;
+pub mod f1_race;

--- a/src/commands/quote.rs
+++ b/src/commands/quote.rs
@@ -394,14 +394,14 @@ pub async fn roll_quote(
     roll_amount: usize,
     db_pool: &MySqlPool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    info!("Connected to {:?}", channel_id);
+    info!("roll_quote: Connected to {:?}", channel_id);
 
     *counter += 1; // Increment counter
-    info!("counter at: {:?}", counter);
+    info!("roll_quote: counter at: {:?}", counter);
     if *counter >= roll_amount {
         *counter = 0; // Reset the counter
 
-        let rand = rand::thread_rng().gen_range(0..100);
+        let rand = rand::rng().random_range(0..100);
         info!("rand generated {:?}", rand);
 
         if rand < 1 {
@@ -453,11 +453,11 @@ pub async fn roll_quote(
                         )
                         .await
                     {
-                        error!("Failed to send random quote: {}", e);
+                        error!("roll_quote: Failed to send random quote: {}", e);
                     }
                 }
                 Err(e) => {
-                    error!("Failed to execute random quote query: {}", e);
+                    error!("roll_quote: Failed to execute random quote query: {}", e);
                 }
             }
         }

--- a/src/commands/quote.rs
+++ b/src/commands/quote.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use log::{info, warn};
+use log::{info, warn, error};
 use rand::Rng;
 use serenity::all::{
     ChannelId, CommandInteraction, CreateInteractionResponse, CreateInteractionResponseMessage,
@@ -19,7 +19,7 @@ pub async fn show_scoreboard(
     ctx: serenity::client::Context,
     command: &CommandInteraction,
     db_pool: &MySqlPool,
-) {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("Fetching scoreboard...");
     let query = "
     WITH latest_names AS (
@@ -71,7 +71,7 @@ pub async fn show_scoreboard(
                 scoreboard.push_str("No scores recorded yet! Start playing with /guessquote");
             }
 
-            if let Err(why) = command
+            if let Err(e) = command
                 .create_response(
                     &ctx.http,
                     CreateInteractionResponse::Message(
@@ -80,7 +80,8 @@ pub async fn show_scoreboard(
                 )
                 .await
             {
-                warn!("Error sending scoreboard: {why}");
+                warn!("Error sending scoreboard: {}", e);
+                return Err(Box::new(e));
             }
         }
         Err(e) => {
@@ -95,17 +96,21 @@ pub async fn show_scoreboard(
                 )
                 .await
             {
-                warn!("Error sending error message: {why}");
+                warn!("Error sending error message: {}", why);
+                return Err(Box::new(why));
             }
+            return Err(Box::new(e));
         }
     }
+    
+    Ok(())
 }
 
 pub async fn guess_quote(
     ctx: serenity::client::Context,
     command: &CommandInteraction,
     db_pool: &MySqlPool,
-) {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Get allowed user IDs from static
     let empty_vec = Vec::new();
     let allowed_users = ALLOWED_QUOTE_USERS.get().unwrap_or(&empty_vec);
@@ -154,8 +159,8 @@ pub async fn guess_quote(
                 )
                 .await
             {
-                warn!("Error sending quote: {why}");
-                return;
+                warn!("Error sending quote: {}", why);
+                return Err(Box::new(why));
             }
 
             // Get the channel ID from the command
@@ -212,10 +217,10 @@ pub async fn guess_quote(
             // Handle no guesses case early
             if guesses.is_empty() {
                 info!("No guesses received for this quote");
-                if let Err(why) = channel_id.say(&ctx.http, response).await {
-                    warn!("Error sending response: {why}");
+                if let Err(e) = channel_id.say(&ctx.http, response).await {
+                    warn!("Error sending response: {}", e);
                 }
-                return;
+                return Ok(());
             }
             
             info!("Processing {} guesses", guesses.len());
@@ -354,9 +359,12 @@ pub async fn guess_quote(
                 }
             }
 
-            if let Err(why) = channel_id.say(&ctx.http, response).await {
-                warn!("Error sending response: {why}");
+            if let Err(e) = channel_id.say(&ctx.http, response).await {
+                warn!("Error sending response: {}", e);
+                return Err(Box::new(e));
             }
+            
+            Ok(())
         }
         Err(e) => {
             warn!("Failed to execute query: {}", e);
@@ -370,8 +378,10 @@ pub async fn guess_quote(
                 )
                 .await
             {
-                warn!("Error sending error message: {why}");
+                warn!("Error sending error message: {}", why);
+                return Err(Box::new(why));
             }
+            Err(Box::new(e))
         }
     }
 }
@@ -383,7 +393,7 @@ pub async fn roll_quote(
     counter: &mut usize,
     roll_amount: usize,
     db_pool: &MySqlPool,
-) {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("Connected to {:?}", channel_id);
 
     *counter += 1; // Increment counter
@@ -391,7 +401,7 @@ pub async fn roll_quote(
     if *counter >= roll_amount {
         *counter = 0; // Reset the counter
 
-        let rand = rand::rng().random_range(0..100);
+        let rand = rand::thread_rng().gen_range(0..100);
         info!("rand generated {:?}", rand);
 
         if rand < 1 {
@@ -432,23 +442,26 @@ pub async fn roll_quote(
                     let timestamp_string = row.4.to_string();
                     // Now split the string and collect into Vec
                     let timestamp: Vec<_> = timestamp_string.split(" ").collect();
-                if let Err(why) = channel_id
-                    .say(
-                        &ctx.http,
-                        &format!(
-                            "> ** <@{}> on {} at {}:**\n> \n> _'{}'_",
-                            row.1, timestamp[0], timestamp[1], row.3
-                        ),
-                    )
-                    .await
-                {
-                        warn!("Something went wrong: {why}");
+                    
+                    if let Err(e) = channel_id
+                        .say(
+                            &ctx.http,
+                            &format!(
+                                "> ** <@{}> on {} at {}:**\n> \n> _'{}'_",
+                                row.1, timestamp[0], timestamp[1], row.3
+                            ),
+                        )
+                        .await
+                    {
+                        error!("Failed to send random quote: {}", e);
                     }
                 }
                 Err(e) => {
-                    warn!("Failed to execute query: {}", e);
+                    error!("Failed to execute random quote query: {}", e);
                 }
             }
         }
     }
+    
+    Ok(())
 }

--- a/src/commands/scraper.rs
+++ b/src/commands/scraper.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::{info, error};
 use serenity::all::ChannelId;
 use serenity::{futures::StreamExt, model::Timestamp};
 use sqlx::MySqlPool;
@@ -10,13 +10,12 @@ pub async fn scrape_messages(
     db_pool: &MySqlPool,
     start_date: Timestamp,
     end_date: Timestamp,
-) {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("Starting scrape");
 
     let mut messages = channel_id.messages_iter(&ctx.http).boxed();
 
     while let Some(message) = messages.next().await {
-        info!("Receiving message....");
         match message {
             Ok(msg) => {
                 if msg.timestamp > start_date && msg.timestamp < end_date.into() {
@@ -43,8 +42,8 @@ pub async fn scrape_messages(
                     ";
 
                     // Execute the query
-                    let _ = sqlx::query(insert_query)
-                        .bind(i64::from(msg.id)) // Assuming msg.id is an ID type that can be converted to i64
+                    if let Err(e) = sqlx::query(insert_query)
+                        .bind(i64::from(msg.id))
                         .bind(i64::from(msg.channel_id))
                         .bind(i64::from(msg.author.id))
                         .bind(msg.author.name)
@@ -53,11 +52,18 @@ pub async fn scrape_messages(
                         .bind(premium_type_str)
                         .execute(db_pool)
                         .await
-                        .map_err(|e| info!("Failed to insert message: {}", e));
+                    {
+                        error!("Failed to insert message: {}", e);
+                        // Continue processing other messages even if one fails
+                    }
                 }
             }
-            Err(why) => info!("Error while fetching a message: {:?}", why),
+            Err(e) => {
+                error!("Error while fetching a message: {:?}", e);
+                // Continue processing other messages
+            }
         }
     }
     info!("Done downloading!");
+    Ok(())
 }

--- a/src/commands/scraper.rs
+++ b/src/commands/scraper.rs
@@ -11,7 +11,7 @@ pub async fn scrape_messages(
     start_date: Timestamp,
     end_date: Timestamp,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    info!("Starting scrape");
+    info!("scrape_messages: Starting scrape");
 
     let mut messages = channel_id.messages_iter(&ctx.http).boxed();
 
@@ -21,7 +21,7 @@ pub async fn scrape_messages(
                 if msg.timestamp > start_date && msg.timestamp < end_date.into() {
                     // Print the message details
                     info!(
-                        "{}@{}@{}@{}@{}@{}@{:?}",
+                        "scrape_messages: {}@{}@{}@{}@{}@{}@{:?}",
                         &msg.id,
                         &msg.channel_id,
                         &msg.author.id,
@@ -64,6 +64,6 @@ pub async fn scrape_messages(
             }
         }
     }
-    info!("Done downloading!");
+    info!("scrape_messages: Done downloading!");
     Ok(())
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,12 +3,13 @@ use serenity::{
     builder::CreateEmbed,
     prelude::*,
 };
+use log::{info, warn};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("version").description("Show bot version information")
 }
 
-pub async fn show_version(ctx: Context, command: &CommandInteraction) {
+pub async fn show_version(ctx: Context, command: &CommandInteraction) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let version = env!("CARGO_PKG_VERSION");
     let build_id = env!("BUILD_ID");
 
@@ -17,7 +18,7 @@ pub async fn show_version(ctx: Context, command: &CommandInteraction) {
         .field("Version", version, true)
         .field("Build ID", build_id, true);
 
-    if let Err(why) = command
+    if let Err(e) = command
         .create_response(
             &ctx.http,
             CreateInteractionResponse::Message(
@@ -26,6 +27,10 @@ pub async fn show_version(ctx: Context, command: &CommandInteraction) {
         )
         .await
     {
-        println!("Cannot respond to slash command: {why}");
+        warn!("Cannot respond to version command: {}", e);
+        return Err(Box::new(e));
     }
+    
+    info!("Version command executed successfully");
+    Ok(())
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -31,6 +31,6 @@ pub async fn show_version(ctx: Context, command: &CommandInteraction) -> Result<
         return Err(Box::new(e));
     }
     
-    info!("Version command executed successfully");
+    info!("show_version: Version command executed successfully");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ impl EventHandler for Handler {
                 None => panic!("Start date not set"),
             };
 
-            info!("Using dates: {start_date} and {end_date}");
+            info!("main: Using dates: {start_date} and {end_date}");
 
             if let Err(e) = scraper::scrape_messages(
                 ctx,
@@ -178,7 +178,7 @@ impl EventHandler for Handler {
                 warn!("Error scraping messages: {:?}", e);
             }
         }
-        info!("{} is connected!", bot.user.name);
+        info!("ready: {} is connected!", bot.user.name);
     }
 
     async fn interaction_create(&self, ctx: Context, interaction: serenity::model::application::Interaction) {
@@ -231,7 +231,7 @@ impl EventHandler for Handler {
             warn!("Error handling roll quote: {:?}", e);
         }
 
-        info!("{}: {} @ {}", msg.author, msg.content, msg.timestamp);
+        info!("message: {}: {} @ {}", msg.author, msg.content, msg.timestamp);
     }
 }
 
@@ -246,7 +246,7 @@ async fn main() {
     let cli_args: cli::CliCommands = cli::CliCommands::parse();
 
     // Generate a random UUID
-    info!("Bot version: {} (build: {})", VERSION, BUILD_ID);
+    info!("main: Bot version: {} (build: {})", VERSION, BUILD_ID);
 
     match setup::setup().await {
         Ok((db_pool, discord_token, channel_id)) => {
@@ -271,7 +271,7 @@ async fn main() {
                 .expect("Error creating client");
 
             if let Err(error) = client.start().await {
-                info!("Client error: {:?}", error);
+                info!("main: Client error: {:?}", error);
             }
         }
         Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,9 @@ use serenity::{
 };
 use sqlx::mysql::MySqlPool;
 use tokio::sync::Mutex;
+use tokio::time::{interval, Duration};
 
-use commands::{quote, scraper, version};
+use commands::{quote, scraper, version, f1_race};
 
 mod cli;
 mod commands;
@@ -119,11 +120,34 @@ impl EventHandler for Handler {
                 .description("Start a game where you have to guess who said a quote"),
             quote::register(),
             version::register(),
+            f1_race::register(),
         ];
 
         Command::set_global_commands(&ctx.http, commands)
             .await
             .expect("Failed to create commands");
+
+        // Clone the context and channel_id for use in the F1 race check task
+        let ctx_clone = ctx.clone();
+        let channel_id = self.channel_id;
+        
+        // Check for upcoming F1 races immediately at startup
+        if let Err(e) = f1_race::check_upcoming_race(ctx.clone(), channel_id).await {
+            warn!("Error checking F1 races at startup: {:?}", e);
+        }
+        
+        // Spawn a task to check for upcoming F1 races every day
+        tokio::spawn(async move {
+            let mut interval = interval(Duration::from_secs(24 * 60 * 60)); // Check every 24 hours
+            
+            loop {
+                interval.tick().await;
+                // This will only send messages on Thursdays
+                if let Err(e) = f1_race::check_upcoming_race(ctx_clone.clone(), channel_id).await {
+                    warn!("Error checking F1 races: {:?}", e);
+                }
+            }
+        });
 
         if self.scraping {
             // let start_date: DateTime<Utc> = Utc::now() - Duration::days(1); // 7 days ago
@@ -143,15 +167,16 @@ impl EventHandler for Handler {
 
             info!("Using dates: {start_date} and {end_date}");
 
-            scraper::scrape_messages(
+            if let Err(e) = scraper::scrape_messages(
                 ctx,
                 &bot,
                 self.channel_id,
                 &self.db_pool,
                 start_date,
                 end_date,
-            )
-            .await;
+            ).await {
+                warn!("Error scraping messages: {:?}", e);
+            }
         }
         info!("{} is connected!", bot.user.name);
     }
@@ -160,15 +185,28 @@ impl EventHandler for Handler {
         if let serenity::model::application::Interaction::Command(command) = interaction {
             match command.data.name.as_str() {
                 "guessquote" => {
-                    quote::guess_quote(ctx, &command, &self.db_pool).await;
+                    if let Err(e) = quote::guess_quote(ctx, &command, &self.db_pool).await {
+                        warn!("Error handling guessquote command: {:?}", e);
+                    }
                 }
                 "scoreboard" => {
-                    quote::show_scoreboard(ctx, &command, &self.db_pool).await;
+                    if let Err(e) = quote::show_scoreboard(ctx, &command, &self.db_pool).await {
+                        warn!("Error handling scoreboard command: {:?}", e);
+                    }
                 }
                 "version" => {
-                    version::show_version(ctx, &command).await;
+                    if let Err(e) = version::show_version(ctx, &command).await {
+                        warn!("Error handling version command: {:?}", e);
+                    }
                 }
-                _ => {}
+                "f1" => {
+                    if let Err(e) = f1_race::handle_commands(ctx, &command).await {
+                        warn!("Error handling F1 command: {:?}", e);
+                    }
+                }
+                _ => {
+                    warn!("Unknown command: {}", command.data.name);
+                }
             }
         }
     }
@@ -181,7 +219,7 @@ impl EventHandler for Handler {
             None => 15, // Default value
         };
 
-        quote::roll_quote(
+        if let Err(e) = quote::roll_quote(
             ctx,
             &msg,
             self.channel_id,
@@ -189,7 +227,9 @@ impl EventHandler for Handler {
             effective_roll_amount,
             &self.db_pool,
         )
-        .await;
+        .await {
+            warn!("Error handling roll quote: {:?}", e);
+        }
 
         info!("{}: {} @ {}", msg.author, msg.content, msg.timestamp);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use sqlx::mysql::MySqlPool;
 use tokio::sync::Mutex;
 use tokio::time::{interval, Duration};
 
-use commands::{quote, scraper, version, f1_race};
+use commands::{quote, scraper, version, f1};
 
 mod cli;
 mod commands;
@@ -120,7 +120,7 @@ impl EventHandler for Handler {
                 .description("Start a game where you have to guess who said a quote"),
             quote::register(),
             version::register(),
-            f1_race::register(),
+            f1::register(),
         ];
 
         Command::set_global_commands(&ctx.http, commands)
@@ -132,7 +132,7 @@ impl EventHandler for Handler {
         let channel_id = self.channel_id;
         
         // Check for upcoming F1 races immediately at startup
-        if let Err(e) = f1_race::check_upcoming_race(ctx.clone(), channel_id).await {
+        if let Err(e) = f1::check_upcoming_race(ctx.clone(), channel_id).await {
             warn!("Error checking F1 races at startup: {:?}", e);
         }
         
@@ -143,7 +143,7 @@ impl EventHandler for Handler {
             loop {
                 interval.tick().await;
                 // This will only send messages on Thursdays
-                if let Err(e) = f1_race::check_upcoming_race(ctx_clone.clone(), channel_id).await {
+                if let Err(e) = f1::check_upcoming_race(ctx_clone.clone(), channel_id).await {
                     warn!("Error checking F1 races: {:?}", e);
                 }
             }
@@ -200,7 +200,7 @@ impl EventHandler for Handler {
                     }
                 }
                 "f1" => {
-                    if let Err(e) = f1_race::handle_commands(ctx, &command).await {
+                    if let Err(e) = f1::handle_commands(ctx, &command).await {
                         warn!("Error handling F1 command: {:?}", e);
                     }
                 }


### PR DESCRIPTION
# F1 Calendar and Race Information API

## Summary
This PR implements functionality to fetch the current F1 race calendar and identify the next upcoming race. The implementation uses the Jolpi API (which replaces the deprecated Ergast F1 API) to retrieve race schedule data for the current season.

## Changes
- Added `fetch_f1_calendar()` function to retrieve the F1 calendar for the current year
- Added `find_next_race()` function to identify the next upcoming race based on the current date
- Added `is_thursday()` utility function to help with race weekend notifications

## Implementation Details
- Calendar data is fetched from the Jolpi API (jolpi.ca), which is the modern replacement for the deprecated Ergast API
- The functions handle date parsing and comparison to find upcoming races
- Error handling is implemented for API requests and date parsing

## Testing
- Verified calendar retrieval for the current season
- Confirmed next race detection works correctly with both past and future races
- Tested date comparison logic with various scenarios

## Next Steps
- Implement race weekend notifications
- Add caching for API responses to reduce external calls
- Expand with additional F1 data (standings, results, etc.)